### PR TITLE
fix: thread safety for Manual functions

### DIFF
--- a/manual.go
+++ b/manual.go
@@ -1,35 +1,71 @@
 package progress
 
+import (
+	"sync"
+	"sync/atomic"
+)
+
 type Manual struct {
-	N     int64
-	Total int64
-	Err   error
+	n        int64
+	total    int64
+	err      error
+	errMutex sync.Mutex
 }
 
-func (p Manual) Current() int64 {
-	return int64(p.N)
-}
-
-func (p Manual) Size() int64 {
-	return int64(p.Total)
-}
-
-func (p Manual) Error() error {
-	return p.Err
-}
-
-func (p Manual) Progress() Progress {
-	return Progress{
-		current: p.N,
-		size:    p.Total,
-		err:     p.Err,
+func NewManual(size int64) *Manual {
+	return &Manual{
+		total: size,
 	}
 }
 
+func (p *Manual) Current() int64 {
+	return atomic.LoadInt64(&p.n)
+}
+
+func (p *Manual) Size() int64 {
+	return atomic.LoadInt64(&p.total)
+}
+
+func (p *Manual) Error() error {
+	p.errMutex.Lock()
+	defer p.errMutex.Unlock()
+	return p.err
+}
+
+func (p *Manual) SetError(err error) {
+	p.errMutex.Lock()
+	defer p.errMutex.Unlock()
+	p.err = err
+}
+
+func (p *Manual) Progress() Progress {
+	return Progress{
+		current: p.Current(),
+		size:    p.Size(),
+		err:     p.Error(),
+	}
+}
+
+func (p *Manual) Add(n int64) {
+	atomic.AddInt64(&p.n, n)
+}
+
+func (p *Manual) Increment() {
+	atomic.AddInt64(&p.n, 1)
+}
+
+func (p *Manual) Set(n int64) {
+	atomic.StoreInt64(&p.n, n)
+}
+
+func (p *Manual) SetTotal(total int64) {
+	atomic.StoreInt64(&p.total, total)
+}
+
 func (p *Manual) SetCompleted() {
-	p.Err = ErrCompleted
-	if p.N > 0 && p.Total <= 0 {
-		p.Total = p.N
+	p.SetError(ErrCompleted)
+	if p.Current() > 0 && p.Size() <= 0 {
+		p.SetTotal(p.Current())
 		return
 	}
 }


### PR DESCRIPTION
This PR fixes an issue that the `progress.Manual` was not being used in a thread-safe way due to exported variables without synchronization.

Related to: https://github.com/anchore/syft/issues/1633