### PR TITLE
Expose atomic update to current stage

### DIFF
--- a/atomic_stage.go
+++ b/atomic_stage.go
@@ -8,7 +8,7 @@ type AtomicStage struct {
 	current atomic.Value
 }
 
-func (s *AtomicStage) getCurrentStage() string {
+func (s *AtomicStage) getCurrent() string {
 	return s.current.Load().(string)
 }
 
@@ -17,7 +17,7 @@ func (s *AtomicStage) setCurrent(new string) {
 }
 
 func (s *AtomicStage) Stage() string {
-	return s.getCurrentStage()
+	return s.getCurrent()
 }
 
 func (s *AtomicStage) Set(new string) {

--- a/atomic_stage.go
+++ b/atomic_stage.go
@@ -1,0 +1,29 @@
+package progress
+
+import "sync/atomic"
+
+type AtomicStage struct {
+	current atomic.Value
+}
+
+func (s *AtomicStage) getCurrentStage() string {
+	return s.current.Load().(string)
+}
+
+func (s *AtomicStage) setCurrent(new string) {
+	s.current.Store(new)
+}
+
+func (s *AtomicStage) Stage() string {
+	return s.getCurrentStage()
+}
+
+func (s *AtomicStage) Set(new string) {
+	s.setCurrent(new)
+}
+
+func NewAtomicStage(current string) *AtomicStage {
+	result := AtomicStage{}
+	result.current.Store(current)
+	return &result
+}

--- a/atomic_stage.go
+++ b/atomic_stage.go
@@ -2,6 +2,8 @@ package progress
 
 import "sync/atomic"
 
+var _ Stager = (*AtomicStage)(nil)
+
 type AtomicStage struct {
 	current atomic.Value
 }

--- a/stage.go
+++ b/stage.go
@@ -1,15 +1,40 @@
 package progress
 
+import "sync/atomic"
+
 type Stager interface {
 	Stage() string
 }
 
 type Stage struct {
-	Current string
+	currentStage atomic.Value
 }
 
-func (s Stage) Stage() string {
-	return s.Current
+func (s *Stage) getCurrentStage() string {
+	return s.currentStage.Load().(string)
+}
+
+func (s *Stage) setCurrentStage(newStage string) {
+	s.currentStage.Store(newStage)
+}
+
+func (s *Stage) Stage() string {
+	return s.getCurrentStage()
+}
+
+func (s *Stage) Set(newStage string) {
+	s.setCurrentStage(newStage)
+}
+
+func NewStage(current string) *Stage {
+	result := Stage{}
+	result.currentStage.Store(current)
+	return &result
+}
+
+type StagerSettable interface {
+	Stager
+	Set(newStage string)
 }
 
 type StagedMonitorable interface {

--- a/stage.go
+++ b/stage.go
@@ -1,40 +1,15 @@
 package progress
 
-import "sync/atomic"
-
 type Stager interface {
 	Stage() string
 }
 
 type Stage struct {
-	currentStage atomic.Value
+	Current string
 }
 
-func (s *Stage) getCurrentStage() string {
-	return s.currentStage.Load().(string)
-}
-
-func (s *Stage) setCurrentStage(newStage string) {
-	s.currentStage.Store(newStage)
-}
-
-func (s *Stage) Stage() string {
-	return s.getCurrentStage()
-}
-
-func (s *Stage) Set(newStage string) {
-	s.setCurrentStage(newStage)
-}
-
-func NewStage(current string) *Stage {
-	result := Stage{}
-	result.currentStage.Store(current)
-	return &result
-}
-
-type StagerSettable interface {
-	Stager
-	Set(newStage string)
+func (s Stage) Stage() string {
+	return s.Current
 }
 
 type StagedMonitorable interface {


### PR DESCRIPTION
The stager is often used in different go routines. The lack of an atomic setter was forcing clients to either manager their own locks or accept a minor race condition.

Here's an example of what it would look like to use these changes:

- Stereoscope: https://github.com/anchore/stereoscope/compare/fix-race-in-go-progress
- Syft: https://github.com/anchore/syft/compare/fix-go-progress-race

Happy for feedback on names, mechanism, etc.