### PR TITLE
fix: make Writer and TimedProgress threadsafe

### DIFF
--- a/timed_progress.go
+++ b/timed_progress.go
@@ -1,13 +1,14 @@
 package progress
 
 import (
+	"sync/atomic"
 	"time"
 )
 
 type TimedProgress struct {
 	start    time.Time
 	duration time.Duration
-	complete bool
+	complete atomic.Bool
 }
 
 func NewTimedProgress(duration time.Duration) *TimedProgress {
@@ -18,12 +19,12 @@ func NewTimedProgress(duration time.Duration) *TimedProgress {
 }
 
 func (r *TimedProgress) Current() int64 {
-	if r.complete {
+	if r.complete.Load() {
 		return r.duration.Milliseconds()
 	}
 	current := time.Since(r.start).Milliseconds()
 	if current > r.duration.Milliseconds() {
-		r.complete = true
+		r.complete.Store(true)
 		current = r.duration.Milliseconds()
 	}
 	return current
@@ -38,5 +39,5 @@ func (r *TimedProgress) Error() error {
 }
 
 func (r *TimedProgress) SetCompleted() {
-	r.complete = true
+	r.complete.Store(true)
 }

--- a/writer.go
+++ b/writer.go
@@ -1,42 +1,45 @@
 package progress
 
+import "sync/atomic"
+
 // Writer will consume a throw away bytes its given (not a passthrough). This is intended to be used with io.MultiWriter
 type Writer struct {
-	current int64
-	size    int64
-	err     error
+	current atomic.Int64
+	size    atomic.Int64
+	done    atomic.Bool
 }
 
 func NewSizedWriter(size int64) *Writer {
-	return &Writer{
-		size: size,
-	}
+	val := &Writer{}
+	val.size.Store(size)
+	return val
 }
 
 func NewWriter() *Writer {
-	return &Writer{
-		size: -1,
-	}
+	return NewSizedWriter(-1)
 }
 
 func (w *Writer) SetComplete() {
-	w.err = ErrCompleted
+	w.done.Store(true)
 }
 
 func (w *Writer) Write(p []byte) (int, error) {
 	n := len(p)
-	w.current += int64(n)
+	w.current.Add(int64(n))
 	return n, nil
 }
 
 func (w *Writer) Current() int64 {
-	return w.current
+	return w.current.Load()
 }
 
 func (w *Writer) Size() int64 {
-	return w.size
+	return w.size.Load()
 }
 
 func (w *Writer) Error() error {
-	return w.err
+	if w.done.Load() {
+		return ErrCompleted
+	}
+	return nil
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -88,5 +89,19 @@ func TestWriter(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestInitialConditions(t *testing.T) {
+	w := NewSizedWriter(42)
+	if w.Error() != nil {
+		t.Errorf("Expected nil error but was %+v", w.Error())
+	}
+	if w.Size() != 42 {
+		t.Errorf("Expect %d size but was %d", 42, w.Size())
+	}
+	w.SetComplete()
+	if !errors.Is(w.Error(), io.EOF) {
+		t.Errorf("SetCompleted should set EOF, but got %+v", w.Error())
 	}
 }


### PR DESCRIPTION
These have led to some detectable race conditions, since go-progress state is often updated from multiple go routines.